### PR TITLE
Add function names for each line

### DIFF
--- a/backend/sync-helper/chromium/models.py
+++ b/backend/sync-helper/chromium/models.py
@@ -13,6 +13,7 @@ class Chromium():
     target_version =    "92.0.4515.0"
     conflicts = []
     blames = {}
+    function_lines = {}
 
     def is_git_repo(path):
         try:
@@ -95,6 +96,8 @@ class Chromium():
         except Exception as e:
             return False 
 
+        Chromium.read_function(path)
+
         msgs = os.popen(f"git blame -l --line-porcelain -L{start},{end} {path}").read().split('\n')[:-1]
 
         blame = []
@@ -132,6 +135,142 @@ class Chromium():
             
         Chromium.blames[id] = blame
         return blame
+
+    def read_function(path):
+        line_index = 1
+        not_func = ['if', 'else if', 'else', 'for', 'while', 'switch', 'do', '{']
+        not_func_name = ['private', 'public', 'const', 'static', 'ALWAYS_INLINE']
+        funclines = {}
+        funclist = []
+        line_func = {}
+        current_func_list = []
+        incoming_func_list = []
+        NORMAL = 0
+        CURRENT = 1
+        INCOMING = 2
+        AFTER_CONF = 3
+        mode = NORMAL
+
+        while True:
+            line = linecache.getline(path, line_index)
+            if line == '':
+                break
+            elif '[this]' in line and '{' in line:
+                funclist.append('not_func')
+                if mode == CURRENT:
+                    current_func_list.append('not_func')
+                elif mode == INCOMING:
+                    incoming_func_list.append('not_func')
+            elif '<<<<<<' in line:
+                mode = CURRENT
+            elif '======' in line:
+                mode = INCOMING
+                for current_func in reversed(current_func_list):
+                    if current_func != 'not_func':
+                        for i in range(funclines[current_func][0], line_index + 1):
+                            try:
+                                line_func[i].append(current_func)
+                            except:
+                                line_func[i] = [current_func]
+
+                funclist = funclist[:-len(current_func_list)]
+            elif '>>>>>>' in line:
+                mode = AFTER_CONF
+                after_line_index = line_index
+            elif '{' in line:
+                detect_index = line_index
+                left_bra, right_bra = 0, 0
+                while True:
+                    detect_line = linecache.getline(path, detect_index)
+                    left_bra += detect_line.count('(')
+                    right_bra += detect_line.count(')')
+                    if left_bra >= right_bra:
+                        break
+                    detect_index -= 1
+
+                blank_count = 0
+                for letter in detect_line:
+                    if letter == ' ':
+                        blank_count += 1
+                    else:
+                        break
+
+                detect_line = detect_line[blank_count:]
+
+                if detect_line.find('(') == 0:
+                    func_name = detect_line[:detect_line.find('(', detect_line.find('(') + 1)].split(' ')[1]
+                else:
+                    try:
+                        func_names = detect_line[:detect_line.find('(')].split(' ')
+                        func_name = [x for x in func_names if x not in not_func_name][1]
+                        if func_name == '':
+                            func_name = [x for x in func_names if x not in not_func_name][0]
+                    except IndexError:
+                        func_name = detect_line[:detect_line.find('(')]
+
+                if func_name[0] == '~':
+                    detect_index -= 1
+                    while True:
+                        detect_line = linecache.getline(path, detect_index)
+                        add_name = detect_line[:detect_line.find('::') + 2]
+                        if ' ' in add_name:
+                            add_name = add_name.split(' ')[-1]
+                        func_name = add_name + func_name[1:]
+                        if not '~' in detect_line:
+                            break
+
+                if any(x in func_name for x in not_func):
+                    funclist.append('not_func')
+                    if mode == CURRENT:
+                        current_func_list.append('not_func')
+                else:
+                    funclines[func_name] = [line_index, 0]
+                    funclist.append(func_name)
+                    if mode == CURRENT:
+                        current_func_list.append(func_name)
+                    elif mode == INCOMING:
+                        incoming_func_list.append(func_name)
+
+            if len(funclist) != 0 and '}' in line:
+                for i in range(0, line.count('}')):
+                    closed_func = funclist[-1]
+                    del funclist[-1]
+                    if mode == CURRENT:
+                        del current_func_list[-1]
+                    if closed_func == 'not_func':
+                        continue
+                    else:
+                        funclines[closed_func][1] = line_index
+                        closed_func_copy = closed_func
+                        if closed_func in incoming_func_list:
+                            closed_func += '(incoming)'
+                        for j in range(funclines[closed_func_copy][0], funclines[closed_func_copy][1] + 1):
+                            try:
+                                line_func[j].append(closed_func)
+                            except:
+                                line_func[j] = [closed_func]
+
+                if mode == AFTER_CONF and len(current_func_list) != 0:
+                    for i in range(0, line.count('}')):
+                        after_closed_func = current_func_list[-1]
+                        del current_func_list[-1]
+                        if after_closed_func == 'not_func':
+                            continue
+                        else:
+                            funclines[after_closed_func][1] = line_index
+                            for j in range(after_line_index, line_index + 1):
+                                try:
+                                    line_func[j].append(after_closed_func + '(current)')
+                                except:
+                                    line_func[j] = [after_closed_func + '(current)']
+
+            line_index += 1
+
+        for line in sorted(line_func.items()):
+            print(line)
+                
+        Chromium().function_lines = sorted(line_func.items())
+        return 0
 
 
 class Conflict():


### PR DESCRIPTION
<img width="790" alt="스크린샷 2022-04-05 오후 10 23 50" src="https://user-images.githubusercontent.com/83649602/161763746-013ed61d-e07a-4ef8-a64c-9dbdeb36e636.png">

read_function 함수에 path를 주면 사진처럼 각 라인마다 가까운 순서대로 열려 있는 함수 리스트를 만듭니다.
다만 여러 줄에 대해 선언되어있는 함수 중 몇몇 케이스에 대해 올바르게 작동하지 않습니다. conflict line과는 관계없는 부분에서 발생하는 오류이긴 하나 현재 .cc 코드 이외의 확장자에 대해서도 작동하지 않으므로 회의 때 논의가 필요해 보입니다.
혹시나 회의 전에 도움을 받을 수도 있지 않을까 해서 올렸습니다.